### PR TITLE
Add new getUserStats method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,25 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
     })
   }
 
+  public async getUserStats(): Promise<SimulationResponse> {
+    const blockDetails = await this.genericProvider.getBlock('latest')
+    const evmBlockNumber = `0x${blockDetails.number.toString(16)}`
+
+    const params = [evmBlockNumber]
+    const request = JSON.stringify(this.prepareBundleRequest('flashbots_getUserStats', params))
+    const response = await this.request(request)
+    if (response.error !== undefined) {
+      return {
+        error: {
+          message: response.error.message,
+          code: response.error.code
+        }
+      }
+    }
+
+    return response.result
+  }
+
   public async simulate(
     signedBundledTransactions: Array<string>,
     blockTag: BlockTag,
@@ -324,7 +343,10 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
     return Promise.all(bundledTransactions.map((bundledTransaction) => this.genericProvider.getTransactionReceipt(bundledTransaction.hash)))
   }
 
-  private prepareBundleRequest(method: 'eth_callBundle' | 'eth_sendBundle', params: Array<string | number | string[]>) {
+  private prepareBundleRequest(
+    method: 'eth_callBundle' | 'eth_sendBundle' | 'flashbots_getUserStats',
+    params: Array<string | number | string[]>
+  ) {
     return {
       method: method,
       params: params,

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export interface TransactionSimulationRevert extends TransactionSimulationBase {
 
 export type TransactionSimulation = TransactionSimulationSuccess | TransactionSimulationRevert
 
-export interface SimulationResponseError {
+export interface RelayResponseError {
   error: {
     message: string
     code: number
@@ -72,11 +72,35 @@ export interface SimulationResponseSuccess {
   firstRevert?: TransactionSimulation
 }
 
-export type SimulationResponse = SimulationResponseSuccess | SimulationResponseError
+export type SimulationResponse = SimulationResponseSuccess | RelayResponseError
+
+export interface GetUserStatsResponseSuccess {
+  signing_address: string
+  blocks_won_total: number
+  bundles_submitted_total: number
+  bundles_error_total: number
+  avg_gas_price_gwei: number
+  blocks_won_last_7d: number
+  bundles_submitted_last_7d: number
+  bundles_error_7d: number
+  avg_gas_price_gwei_last_7d: number
+  blocks_won_last_numberd: number
+  bundles_submitted_last_numberd: number
+  bundles_error_numberd: number
+  avg_gas_price_gwei_last_numberd: number
+  blocks_won_last_numberh: number
+  bundles_submitted_last_numberh: number
+  bundles_error_numberh: number
+  avg_gas_price_gwei_last_numberh: number
+  blocks_won_last_5m: number
+  bundles_submitted_last_5m: number
+  bundles_error_5m: number
+  avg_gas_price_gwei_last_5m: number
+}
+
+type GetUserStatsResponse = GetUserStatsResponseSuccess | RelayResponseError
 
 const TIMEOUT_MS = 5 * 60 * 1000
-
-const SECONDS_PER_BLOCK = 15
 
 export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
   private genericProvider: BaseProvider
@@ -156,7 +180,9 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
       simulate: () =>
         this.simulate(
           bundleTransactions.map((tx) => tx.signedTransaction),
-          targetBlockNumber
+          targetBlockNumber,
+          undefined,
+          opts?.minTimestamp
         ),
       receipts: () => this.fetchReceipts(bundleTransactions)
     }
@@ -262,7 +288,7 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
     })
   }
 
-  public async getUserStats(): Promise<SimulationResponse> {
+  public async getUserStats(): Promise<GetUserStatsResponse> {
     const blockDetails = await this.genericProvider.getBlock('latest')
     const evmBlockNumber = `0x${blockDetails.number.toString(16)}`
 
@@ -305,7 +331,7 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
       evmBlockStateNumber = stateBlockTag
     }
 
-    const params: any[] = [signedBundledTransactions, evmBlockNumber, evmBlockStateNumber]
+    const params: Array<string[] | string | number> = [signedBundledTransactions, evmBlockNumber, evmBlockStateNumber]
     if (blockTimestamp) {
       params.push(blockTimestamp)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,9 @@ export interface GetUserStatsResponseSuccess {
   avg_gas_price_gwei_last_5m: number
 }
 
-type GetUserStatsResponse = GetUserStatsResponseSuccess | RelayResponseError
+export type GetUserStatsResponse = GetUserStatsResponseSuccess | RelayResponseError
+
+type RpcParams = Array<string[] | string | number>
 
 const TIMEOUT_MS = 5 * 60 * 1000
 
@@ -331,7 +333,7 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
       evmBlockStateNumber = stateBlockTag
     }
 
-    const params: Array<string[] | string | number> = [signedBundledTransactions, evmBlockNumber, evmBlockStateNumber]
+    const params: RpcParams = [signedBundledTransactions, evmBlockNumber, evmBlockStateNumber]
     if (blockTimestamp) {
       params.push(blockTimestamp)
     }
@@ -369,10 +371,7 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
     return Promise.all(bundledTransactions.map((bundledTransaction) => this.genericProvider.getTransactionReceipt(bundledTransaction.hash)))
   }
 
-  private prepareBundleRequest(
-    method: 'eth_callBundle' | 'eth_sendBundle' | 'flashbots_getUserStats',
-    params: Array<string | number | string[]>
-  ) {
+  private prepareBundleRequest(method: 'eth_callBundle' | 'eth_sendBundle' | 'flashbots_getUserStats', params: RpcParams) {
     return {
       method: method,
       params: params,


### PR DESCRIPTION
Returns:
```
{
  signing_address: '0x...',
  blocks_won_total: 0,
  bundles_submitted_total: 119,
  bundles_error_total: 0,
  avg_gas_price_gwei: 14.713448192860085,
  blocks_won_last_7d: 0,
  bundles_submitted_last_7d: 119,
  bundles_error_7d: 0,
  avg_gas_price_gwei_last_7d: 14.713448192860085,
  blocks_won_last_1d: 0,
  bundles_submitted_last_1d: 119,
  bundles_error_1d: 0,
  avg_gas_price_gwei_last_1d: 14.713448192860085,
  blocks_won_last_1h: 0,
  bundles_submitted_last_1h: 119,
  bundles_error_1h: 0,
  avg_gas_price_gwei_last_1h: 14.713448192860085,
  blocks_won_last_5m: 0,
  bundles_submitted_last_5m: 113,
  bundles_error_5m: 0,
  avg_gas_price_gwei_last_5m: 14.703869303144744
}
```

Possible improvements:
* group fields by time period
* let users inspect other users (right now the relay requires auth and only lets you see yourself)