### PR TITLE
Searching through all block's Tx instead of lasts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -272,8 +272,12 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
         } else {
           const block = await this.genericProvider.getBlock(targetBlockNumber)
           // check bundle against block:
+          const blockTransactionsHash: {[key:string]: boolean} = {};
+          for(const bt of block.transactions){
+            blockTransactionsHash[bt] = true;
+          }
           const bundleIncluded = transactionAccountNonces.every(
-            (transaction, i) => block.transactions[block.transactions.length - 1 - i] === transaction.hash
+            (transaction) => blockTransactionsHash[transaction.hash] === true
           )
           resolve(bundleIncluded ? FlashbotsBundleResolution.BundleIncluded : FlashbotsBundleResolution.BlockPassedWithoutInclusion)
         }


### PR DESCRIPTION
Fixes returning BundleIncluded for successful transactions, when Tx are not at the end of the block.