### PR TITLE
Add support for `error` field being `null`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
 
     const request = JSON.stringify(this.prepareBundleRequest('eth_sendBundle', [params]))
     const response = await this.request(request)
-    if (response.error !== undefined) {
+    if (response.error !== undefined && response.error !== null) {
       return {
         error: {
           message: response.error.message,
@@ -317,7 +317,7 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
     const params = [evmBlockNumber]
     const request = JSON.stringify(this.prepareBundleRequest('flashbots_getUserStats', params))
     const response = await this.request(request)
-    if (response.error !== undefined) {
+    if (response.error !== undefined && response.error !== null) {
       return {
         error: {
           message: response.error.message,
@@ -358,7 +358,7 @@ export class FlashbotsBundleProvider extends providers.JsonRpcProvider {
     ]
     const request = JSON.stringify(this.prepareBundleRequest('eth_callBundle', params))
     const response = await this.request(request)
-    if (response.error !== undefined) {
+    if (response.error !== undefined && response.error !== null) {
       return {
         error: {
           message: response.error.message,


### PR DESCRIPTION
Without this patch, receiving

```
{"id":0,"result":true,"error":null,"jsonrpc":"2.0"}
```

instead of

```
{"id":0,"result":true,"jsonrpc":"2.0"}
```

results in the following error:
```
TypeError: Cannot read property 'message' of null
    at FlashbotsBundleProvider.sendRawBundle
```